### PR TITLE
Laravel 9 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,11 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0]
-        laravel: [8.*]
+        laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.*
-            testbench: ^6.23
+          - laravel: 9.*
+            testbench: ^7.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
         "php": "^8.0.2",
         "spatie/laravel-package-tools": "^1.9.2",
         "filament/filament": "^2.0",
-        "illuminate/contracts": "^8.73|^9.0"
+        "illuminate/contracts": "^9.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.10",
-        "nunomaduro/larastan": "^1.0",
-        "orchestra/testbench": "^6.22",
+        "nunomaduro/collision": "^6.0",
+        "nunomaduro/larastan": "^2.0.1",
+        "orchestra/testbench": "^7.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0.2",
         "spatie/laravel-package-tools": "^1.9.2",
         "filament/filament": "^2.0",
-        "illuminate/contracts": "^8.73"
+        "illuminate/contracts": "^8.73|^9.0"
     },
     "require-dev": {
         "nunomaduro/collision": "^5.10",


### PR DESCRIPTION
Bumped the min php version to `8.0.2` and support `illuminate/contracts` `^9.0` for Laravel 9.